### PR TITLE
Update build-time dependencies

### DIFF
--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -71,9 +71,10 @@ task Init CreateFolders, GenerateVersionInformation
 
 # Synopsis: Compile the Visual Studio solution
 task Compile Init, UpdateVersionInfo, {
+    use 15.0 MSBuild
     try {
         exec {
-            & "C:\Program Files (x86)\MSBuild\14.0\Bin\msbuild" `
+            & MSBuild `
                 $Solution `
                 /maxcpucount `
                 /nodereuse:false `

--- a/.build/paket.dependencies
+++ b/.build/paket.dependencies
@@ -1,12 +1,12 @@
-source https://nuget.org/api/v2
-source http://nuget.red-gate.com/api/v2
+source https://api.nuget.org/v3/index.json
+source https://red-gate.pkgs.visualstudio.com/_packaging/Main/nuget/v3/index.json
 
 # You'll probably need nuget.exe in order to `nuget restore`, `nuget pack` and `nuget push`
-nuget Nuget.CommandLine ~> 3
+nuget Nuget.CommandLine ~> 4.7.1
 
 # https://github.com/nightroman/Invoke-Build
 # https://github.com/nightroman/Invoke-Build/wiki/Script-Tutorial
-nuget Invoke-Build ~> 3
+nuget Invoke-Build ~> 5.4
 
 # Contains useful helper functions for powershell build scripts
-nuget RedGate.Build ~> 0.1
+nuget RedGate.Build ~> 2.1


### PR DESCRIPTION
Motivation: being able to move off the legacy build agents.