### PR TITLE
Allow passing in a connection string instead of an open SqlConnection to ScriptAsAlter

### DIFF
--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -13,7 +13,7 @@ $OutputDir = "$RootDir\.output\$Configuration"
 $LogsDir = "$OutputDir\logs"
 $NugetPackageOutputDir = "$OutputDir\nugetpackages"
 $Solution = "$RootDir\SIPFrameworkShared.sln"
-$PublishNugetPackages = $env:TEAMCITY_VERSION -and $IsDefaultBranch
+$PublishNugetPackages = $env:TEAMCITY_VERSION
 $NugetExe = "$PSScriptRoot\packages\Nuget.CommandLine\tools\Nuget.exe" | Resolve-Path
 
 task CreateFolders {

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ UpgradeLog*.XML
 *.DotSettings
 .build/paket.lock
 .paket/paket.exe
+.vs/

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,5 @@
-# 1.0
+# 1.1
+- ScriptAsAlter now takes a connection string instead of an open SqlConnection
 
+# 1.0
 - Introduce build script so that we can reproduce our builds

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,5 @@
 # 1.1
-- ScriptAsAlter now takes a connection string instead of an open SqlConnection
+- Allow passing in a connection string instead of an open SqlConnection to ScriptAsAlter
 
 # 1.0
 - Introduce build script so that we can reproduce our builds

--- a/SIPFrameworkShared/IServerManagementObjectsAdapter.cs
+++ b/SIPFrameworkShared/IServerManagementObjectsAdapter.cs
@@ -7,6 +7,10 @@ namespace RedGate.SIPFrameworkShared
     {
         [Obsolete("Pass in a connection string, not an open SqlConnection")]
         string ScriptAsAlter(SqlConnection openSqlConnection, string databaseName, string schemaName, string scriptableObjectName);
+    }
+
+    public interface IServerManagementObjectsAdapter2 : IServerManagementObjectsAdapter
+    {
         string ScriptAsAlter(string connectionString, string databaseName, string schemaName, string scriptableObjectName);
     }
 }

--- a/SIPFrameworkShared/IServerManagementObjectsAdapter.cs
+++ b/SIPFrameworkShared/IServerManagementObjectsAdapter.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Data.SqlClient;
 
 namespace RedGate.SIPFrameworkShared
 {
     public interface IServerManagementObjectsAdapter
     {
+        [Obsolete("Pass in a connection string, not an open SqlConnection")]
         string ScriptAsAlter(SqlConnection openSqlConnection, string databaseName, string schemaName, string scriptableObjectName);
+        string ScriptAsAlter(string connectionString, string databaseName, string schemaName, string scriptableObjectName);
     }
 }

--- a/SIPFrameworkShared/ISsmsFunctionalityProvider.cs
+++ b/SIPFrameworkShared/ISsmsFunctionalityProvider.cs
@@ -210,4 +210,14 @@ namespace RedGate.SIPFrameworkShared
         /// </summary>
         new IObjectExplorerWatcher2 ObjectExplorerWatcher { get; }
     }
+
+    public interface ISsmsFunctionalityProvider8 : ISsmsFunctionalityProvider7
+    {
+        /// <summary>
+        /// A wrapper around SMO functions.
+        /// 
+        /// Every version of SSMS loads a different version of SMO. If you can't provide your own SMO implementation this provides a common interface across the one SSMS has loaded.
+        /// </summary>
+        new IServerManagementObjectsAdapter2 ServerManagementObjects { get; }
+    }
 }


### PR DESCRIPTION
Azure SQL Database SqlConnection objects don't expose the password used to connect, which breaks things that need to make a new connection. So, instead, pass in the connection string that definitely contains all the relevant information.