### PR TITLE
Update NuGet.CommandLine

### DIFF
--- a/.build/paket.dependencies
+++ b/.build/paket.dependencies
@@ -5,4 +5,4 @@ nuget RedGate.Build ~> 4.1
 source https://api.nuget.org/v3/index.json
 
 nuget Invoke-Build ~> 5.5 >= 5.5.5
-nuget Nuget.CommandLine ~> 4.7.1
+nuget NuGet.CommandLine ~> 5.5


### PR DESCRIPTION
Older versions of NuGet.CommandLine have problems when running on build agents with newest Visual Studio – specifically NuGet 4.7 is incompatible with VS2019 16.5 – so it's important to keep NuGet up to date to ensure builds continue to work as build agents get upgraded.